### PR TITLE
Clear queue in decorator for subsequent use

### DIFF
--- a/example/usage_example.py
+++ b/example/usage_example.py
@@ -18,3 +18,6 @@ if __name__ == '__main__':
     print("It would cost much time.")
     demo()
     print("Download success!")
+    print("Try again.")
+    demo()
+    print("Yeah!")

--- a/pyspin/spin.py
+++ b/pyspin/spin.py
@@ -74,6 +74,7 @@ def make_spin(spin_style=Default, words=""):
                       end="")
                 sys.stdout.flush()
                 time.sleep(0.1)
+            queue.get()
             print('')
         return wrapper
     return decorator


### PR DESCRIPTION
When a function decorated with `make_spin` is called multiple times, the spinner would only work during its first call. For subsequent calls `queue.empty()` evaluates to `False` and hence the spinner doesn't display (though the wrapped code executes). This pull request fixes this issue by calling `queue.get()` as soon as the while-loop exits. See http://stackoverflow.com/a/16462765

A second call to `demo()` has been added to the example to test/illustrate the issue.
