### PR TITLE
Some sys magic to workaround the unicode problem

### DIFF
--- a/pyspin/spin.py
+++ b/pyspin/spin.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 from __future__ import absolute_import, print_function
 
 import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 import time
 from functools import wraps
 from concurrent.futures import ThreadPoolExecutor


### PR DESCRIPTION
This fixes a bug when a project depending on this is built with pyinstaller specifically. You will see something like the following error when running the dist binary:

Traceback (most recent call last):
  ...
  File "site-packages/pyspin/spin.py", line 68, in wrapper
UnicodeEncodeError: 'ascii' codec can't encode character u'\u280b' in position 1: ordinal not in range(128)
Failed to execute script