### PR TITLE
future dependency should only be installed in python version 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     setup_requires=[
         'setuptools >= 20.8.1',
     ],
-    install_requires=[
-        'futures; python_version < "3.2"',
-    ],
+    extras_require={
+        ':python_version == "2.7"': ['futures']
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     setup_requires=[
         'setuptools >= 20.8.1',
     ],
-    extras_require={
-        ':python_version == "2.7"': ['futures']
+    install_requires={
+        'futures; python_version == "2.7"'
     }
 )


### PR DESCRIPTION
At least on futures docs, it says it shouldn't be installed in any python 3 version